### PR TITLE
Use instance vars to format message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "concourse-resource"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73681060b84ff299e3a59f7188945da55673de178a204e703596741eea61755e"
+checksum = "2fd981419229f45ff6dc9635d5505a9567c45ca990babe7d3a0f657cc44925e6"
 dependencies = [
  "concourse-resource-derive",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 reqwest = { version = "0.11", features = [ "blocking", "json" ] }
-concourse-resource = { git = "https://github.com/aoldershaw/concourse-resource-rs", branch = "add-instance-vars" }
+concourse-resource = "0.2"
 slack_push = { git = "https://github.com/mockersf/slack-push" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 reqwest = { version = "0.11", features = [ "blocking", "json" ] }
-concourse-resource = "0.2"
+concourse-resource = { git = "https://github.com/aoldershaw/concourse-resource-rs", branch = "add-instance-vars" }
 slack_push = { git = "https://github.com/mockersf/slack-push" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,6 +336,7 @@ impl SlackNotifier {
                     .as_ref()
                     .map(String::as_ref)
                     .unwrap_or(""),
+                metadata.pipeline_instance_vars,
                 metadata.job_name.as_ref().map(String::as_ref).unwrap_or(""),
                 metadata
                     .name


### PR DESCRIPTION
Follow-up to (and depends on) mockersf/concourse-resource-rs#1, which adds a pipeline instance vars to the `BuildMetadata`. For context, I'll copy the PR description:

> I'm a member of the Concourse team, and one feature we're adding to Concourse v7.0.0 is pipeline instances. The RFC outlines the motivations for the feature/how it works at a high-level. One implication of pipeline instances is that the team name + pipeline name is no longer sufficient to uniquely identify a pipeline in general - pipeline instances are also identified by their "instance vars", which is some JSON object. For instance, you may have an instance group called release, and several pipeline instances for different versions, e.g.
    ```
    {"version": "6.7.x"}
    {"version": "7.0.x"}
    ...
    ```
    Accordingly, resources are now given the instance vars as a JSON encoded string in BUILD_PIPELINE_INSTANCE_VARS. Regular pipelines will have this env var unset.

---

This updates the job+build name in the message to display the instance vars in the job reference, and updates the build URL with the appropriate query params. e.g.

<img width="565" alt="Screen Shot 2021-01-22 at 11 25 31 AM" src="https://user-images.githubusercontent.com/26583442/105517043-8aeb4b00-5ca4-11eb-9eb1-a684047b3628.png">

Note that the format of the pipeline/job reference is meant to mimic how you interact with pipeline instances in fly. For the above example, we could say:

```sh
$ fly -t ci trigger-job -j 'release/type:"hg"/build-alpine'
# the quotes are optional here
$ fly -t ci trigger-job -j release/type:hg/build-alpine
```

---

Of course open to any/all feedback! I'm very much a rust novice, so if I did something in a stupid way, please let me know (I'd love to learn best practices!)